### PR TITLE
doc(readme): Adicionar badge do projeto ServeRest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ServeRestTest
+[![Badge ServeRest](https://img.shields.io/badge/API-ServeRest-green)](https://github.com/ServeRest/ServeRest/)
 
 ### 🎯 O Desafio
 Esse desafio tem por intúito se tornar como um portifólio e instrumento de estudo de testes de API.


### PR DESCRIPTION
Olá Natanael, essa sugestão tem o propósito de adicionar a badge do ServeRest. O resultado seria esse:

![image](https://github.com/user-attachments/assets/cac77b40-f3fa-4722-b0b0-c8b91404bdf8)

---

## Off topic:

Vi o seu comentário elogiando o ServeRest no README e gostaria de dizer que fiquei feliz ao ver ele. Fico grato de saber que esse projeto está sendo útil para ti e para outras pessoas. Um abraço :D